### PR TITLE
Respect the KUBECONFIG env var if present.

### DIFF
--- a/cmd/kube-resource-explorer/main.go
+++ b/cmd/kube-resource-explorer/main.go
@@ -46,7 +46,9 @@ func main() {
 		kubeconfig *string
 	)
 
-	if home := homeDir(); home != "" {
+	if kubeenv := os.Getenv("KUBECONFIG"); kubeenv != "" {
+		kubeconfig = flag.String("kubeconfig", kubeenv, "absolute path to the kubeconfig file")
+	} else if home := homeDir(); home != "" {
 		kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
 	} else {
 		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")


### PR DESCRIPTION
I use the KUBECONFIG env var to switch between clusters on a per session basis and I wanted to use your tool without having to specify -kubeconfig each run. 